### PR TITLE
Add positions to the win and score messages

### DIFF
--- a/backend/game.logic.ts
+++ b/backend/game.logic.ts
@@ -175,7 +175,11 @@ export class GameArea
             type: "score",
             scorer: player,
             p1Score: this.p1Score,
-            p2Score: this.p2Score
+            p2Score: this.p2Score,
+            ballX: this.ball.x,
+            ballY: this.ball.y,
+            player1Y: this.p1.y,
+            player2Y: this.p2.y
         }
 
         let message = JSON.stringify(scoreData);
@@ -202,7 +206,11 @@ export class GameArea
             type: "win",
             winner: player,
             p1Score: this.p1Score,
-            p2Score: this.p2Score
+            p2Score: this.p2Score,
+            ballX: this.ball.x,
+            ballY: this.ball.y,
+            player1Y: this.p1.y,
+            player2Y: this.p2.y
         }
 
         let message = JSON.stringify(win);
@@ -317,7 +325,7 @@ export class Ball
     moveSpeed: number = 1;
     moveAcel: number = 0.1;
 
-    constructor(x: number, y: number, r = 2)
+    constructor(x: number, y: number, r = 1)
     {
         this.x = x;
         this.y = y;

--- a/backend/game.schema.ts
+++ b/backend/game.schema.ts
@@ -73,7 +73,11 @@ export interface GameScoreData extends GameInterface
 	type: "score",
 	scorer: "player1" | "player2",
 	p1Score: number,
-	p2Score: number
+	p2Score: number,
+	ballX: number,
+	ballY: number,
+	player1Y: number,
+	player2Y: number
 }
 
 export interface GameWinData extends GameInterface
@@ -81,5 +85,9 @@ export interface GameWinData extends GameInterface
 	type: "win",
 	winner: "player1" | "player2",
 	p1Score: number,
-	p2Score: number
+	p2Score: number,
+	ballX: number,
+	ballY: number,
+	player1Y: number,
+	player2Y: number
 }

--- a/frontend/scripts/game.schema.ts
+++ b/frontend/scripts/game.schema.ts
@@ -73,7 +73,11 @@ export interface GameScoreData extends GameInterface
 	type: "score",
 	scorer: "player1" | "player2",
 	p1Score: number,
-	p2Score: number
+	p2Score: number,
+	ballX: number,
+	ballY: number,
+	player1Y: number,
+	player2Y: number
 }
 
 export interface GameWinData extends GameInterface
@@ -81,5 +85,9 @@ export interface GameWinData extends GameInterface
 	type: "win",
 	winner: "player1" | "player2",
 	p1Score: number,
-	p2Score: number
+	p2Score: number,
+	ballX: number,
+	ballY: number,
+	player1Y: number,
+	player2Y: number
 }

--- a/frontend/scripts/game/online/online.controller.ts
+++ b/frontend/scripts/game/online/online.controller.ts
@@ -130,6 +130,12 @@ export class GameArea
         case "score":
         {
             const info = (data as GameSchema.GameScoreData);
+            this.p1Score = info.p1Score;
+            this.p2Score = info.p2Score;
+            this.ball.x = info.ballX;
+            this.ball.y = info.ballY;
+            this.p1.y = info.player1Y;
+            this.p2.y = info.player2Y;
             if (info.scorer === "player1")
                 this.score(this.p1);
             else
@@ -138,21 +144,21 @@ export class GameArea
                 console.warn("p1 score has differed");
             if (this.p2Score !== info.p2Score)
                 console.warn("p2 score has differed");
-            this.p1Score = info.p1Score;
-            this.p2Score = info.p2Score;
-            this.draw();
             break;
         }
         case "win":
         {
             const info = (data as GameSchema.GameWinData);
+            this.p1Score = info.p1Score;
+            this.p2Score = info.p2Score;
+            this.ball.x = info.ballX;
+            this.ball.y = info.ballY;
+            this.p1.y = info.player1Y;
+            this.p2.y = info.player2Y;
             if (info.winner === "player1")
                 this.win(this.p1);
             else
                 this.win(this.p2);
-            this.p1Score = info.p1Score;
-            this.p2Score = info.p2Score;
-            this.drawScore();
             break;
         }
         default:
@@ -186,12 +192,10 @@ export class GameArea
         ctx.fillStyle = TEXT_COLOR;
         if (scorer == this.p1)
         {
-            this.p1Score++;
             ctx.fillText("Left player scored!", this.canvas.width / 2, 200);
         }
         else
         {
-            this.p2Score++;
             ctx.fillText("Right player scored!", this.canvas.width / 2, 200);
         }
     }
@@ -201,22 +205,16 @@ export class GameArea
         let ctx = this.context;
 
         clearInterval(this.interval);
+        this.draw();
+        ctx.font = "48px serif";
+        ctx.textAlign = "center";
+        ctx.fillStyle = TEXT_COLOR;
         if (winner == this.p1)
         {
-            this.p1Score++;
-            this.draw();
-            ctx.font = "48px serif";
-            ctx.textAlign = "center";
-            ctx.fillStyle = TEXT_COLOR;
             ctx.fillText("Left player wins!", this.canvas.width / 2, this.canvas.height / 2);
         }
         else
         {
-            this.p2Score++;
-            this.draw();
-            ctx.font = "48px serif";
-            ctx.textAlign = "center";
-            ctx.fillStyle = TEXT_COLOR;
             ctx.fillText("Right player wins!", this.canvas.width / 2, this.canvas.height / 2);
         }
     }


### PR DESCRIPTION

Fix #7 
Add positions data to the win and score messages during online games.

Reorder some drawing and scoring as well.