### PR TITLE
Fix client disconnect causing game to end

### DIFF
--- a/backend/game.logic.ts
+++ b/backend/game.logic.ts
@@ -58,8 +58,8 @@ export class GameArea
             framerate: this.framerate,
             batHeight: this.p1.h,
             batSpeed: this.p1.moveSpeed,
-            p1Color: "#000",
-            p2Color: "#000",
+            p1Color: undefined,
+            p2Color: undefined,
             ballRadius: this.ball.r,
             ballSpeed: this.ball.moveSpeed,
             ballAcel: this.ball.moveAcel

--- a/backend/game.ts
+++ b/backend/game.ts
@@ -159,12 +159,13 @@ class Game extends GameArea
             {
                 // if there are no sockets connected, and there's no winFunction
                 // just kill this game
-                if (wss.clients.entries.length === 0)
+                if (wss.clients.size === 0)
                 {
                     console.log(`Game (${game.id}) empty, remove in 10 seconds`);
                     game.timeout = setTimeout(() =>
                     {
                         gameWebSocketServers.delete(game.id);
+                        console.log(`Game deleted (${game.id})`);
                     }, 10000)
                 }
             });


### PR DESCRIPTION

Fix #8 
Clients disconnecting from a game with players remaining no longer kill the game.

Server will now send `undefined` instead of `#000` for both p1 and p2 colors.